### PR TITLE
Fixing error suppression issue

### DIFF
--- a/grunt-metastore/package.json
+++ b/grunt-metastore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-metastore",
   "description": "data metastore grunt task",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "homepage": "https://github.com/azulus/metastore",
   "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)"

--- a/grunt-metastore/tasks/metastore.js
+++ b/grunt-metastore/tasks/metastore.js
@@ -38,12 +38,15 @@ var enqueuePromiseGenerator = function (fn, maxSimultaneous) {
         fnPromise.then(function () {
             numRunning--;
             process.nextTick(runNext);
+        }, function(err) {
+            numRunning--;
+            process.nextTick(runNext);
         });
 
         fnPromise.then(function (data){
             next.resolve(data);
         }, function(err) {
-            next.reject(data);
+            next.reject(err);
         });
     };
 
@@ -222,6 +225,7 @@ module.exports = function(grunt) {
             done();
         }, function (err) {
             grunt.log.error(err);
+            done(false);
         });
     });
 };


### PR DESCRIPTION
The grunt-metastore task is apparently suppressing valid errors, this should help surface them correctly
